### PR TITLE
++version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "keywords": ["url", "domain", "subdomaon", "tld", "parse"],
   "main": "./index",
   "dependencies": {
-    "request": "2.1.1"
+    "request": "2.2.9"
   },
   "repository" : {"type": "git" , "url": "http://github.com/masylum/tldextract.git" },
   "engines": { "node": ">= 0.4.0" }


### PR DESCRIPTION
The old request version leaked a variable `i` causing test suites to fail if they have global detection turned on. The latest request solves this issue and the tests are still passing.
